### PR TITLE
Fix duplicate virtual button 13/14 issue.

### DIFF
--- a/buttons_ref.h
+++ b/buttons_ref.h
@@ -2,8 +2,8 @@
 #define BUTTONS_REF_H
 #include <linux/uinput.h>	//Reference to keycodes
 
-#define BUTTONS_SIZE		54
-#define AXES_SIZE			19
+#define BUTTONS_SIZE		53
+#define AXES_SIZE		19
 
 namespace buttons_ref
 {
@@ -22,7 +22,6 @@ BTN_BASE4,
 BTN_BASE5,
 BTN_BASE6,
 BTN_DEAD,
-BTN_TRIGGER_HAPPY,
 BTN_TRIGGER_HAPPY1,
 BTN_TRIGGER_HAPPY2,
 BTN_TRIGGER_HAPPY3,

--- a/main.cc
+++ b/main.cc
@@ -36,7 +36,7 @@ int l_send_keyboard_event(lua_State* L)
 //Called from user via lua script
 int l_get_joy_button_status(lua_State* L)
 {
-	int id = lua_tonumber(L, 1);
+	unsigned int id = lua_tonumber(L, 1);
 	int type = lua_tonumber(L, 2);
 	if(id>=GLOBAL::joyList.size())
 	{
@@ -53,7 +53,7 @@ int l_get_joy_button_status(lua_State* L)
 //Called from user via lua script
 int l_get_joy_axis_status(lua_State* L)
 {
-	int id = lua_tonumber(L, 1);
+	unsigned int id = lua_tonumber(L, 1);
 	int type = lua_tonumber(L, 2);
 	if(id>=GLOBAL::joyList.size())
 	{
@@ -69,7 +69,7 @@ int l_get_joy_axis_status(lua_State* L)
 //Called from user via lua script
 int l_send_vjoy_button_event(lua_State* _L)
 {
-	int id = lua_tonumber(_L, 1);
+	unsigned int id = lua_tonumber(_L, 1);
 	int type = lua_tonumber(_L, 2);
 	int value = lua_tonumber(_L, 3);
 
@@ -85,7 +85,7 @@ int l_send_vjoy_button_event(lua_State* _L)
 //Called from user via lua script
 int l_send_vjoy_axis_event(lua_State* _L)
 {
-	int id = lua_tonumber(_L, 1);
+	unsigned int id = lua_tonumber(_L, 1);
 	int type = lua_tonumber(_L, 2);
 	int value = lua_tonumber(_L, 3);
 
@@ -102,7 +102,7 @@ int l_send_vjoy_axis_event(lua_State* _L)
 //Called from user via lua script
 int l_get_vjoy_button_status(lua_State* L)
 {
-	int id = lua_tonumber(L, 1);
+	unsigned int id = lua_tonumber(L, 1);
 	int type = lua_tonumber(L, 2);
 	if(id>=GLOBAL::vJoyList.size())
 	{
@@ -119,7 +119,7 @@ int l_get_vjoy_button_status(lua_State* L)
 //Called from user via lua script
 int l_get_vjoy_axis_status(lua_State* L)
 {
-	int id = lua_tonumber(L, 1);
+	unsigned int id = lua_tonumber(L, 1);
 	int type = lua_tonumber(L, 2);
 	if(id>=GLOBAL::vJoyList.size())
 	{


### PR DESCRIPTION
BTN_TRIGGER_HAPPY and BTN_TRIGGER_HAPPY1 map to the same input event
code.  If both are present in buttons_ref.h, physical button mapped to
virtual button 13 and physical button mapped to virtual 14 will BOTH
generate events on virtual button 13 and ANY mappings higher than 13
will end up being mapped to a virtual button index one less than
intended
