### PR TITLE
Install as a service + IL2 BOS Missing slider axis

### DIFF
--- a/il2_missing_axis.lua
+++ b/il2_missing_axis.lua
@@ -1,0 +1,57 @@
+-- ##########
+-- IL2 Sturmovik Battle of Stalingrad does not recognize the sliders axis of the throtle and pedals.
+-- This config creates a virtual joystick with those 2 axis.
+-- It also makes the button 2(1) of the throtle a modifier, to use it as the LEFT ALT key.
+-- ##########
+
+--Physical devices to use (type lsusb in terminal to list your connected devices)
+devices = 
+   {
+      d0 = --Thrustmaster Throttle
+	 {
+	    vendorid = 0x044f,
+	    productid = 0xb687,
+	 }
+   }
+
+--Virtual devices to create, current limit is maximum 53 (0 to 52) buttons and 19 (0 to 18) axes. Note that not every button or axis is fully tested to work.
+--Creating more than one virtual devices is possible, making room for more buttons and axes.
+v_devices = 
+   {
+      v0 = 
+	 {
+	    buttons = 1,
+	    axes = 2
+	 }
+   }
+
+-- Send method for keyboard. Key is given, i.e. KEY_G (check reference document for more supported key-codes), and state is given, i.e. 0 for release or 1 for press.
+-- send_keyboard_event(key, state)
+
+-- Send methods for virtual devices. Index of virtual device is given, i.e. 0 for v0, 1 for v1 and so on. Button/axis is given, i.e. 0 for button 0, 1 for button 1 and so on.
+-- send_button_event(vjoy, button, state)
+-- send_axis_event(vjoy, axis, pos)			//pos is the axis position (-32767 >= pos <= 32767)
+
+-- Get methods for physical devices. Arguments applies in the same way as for above methods.
+-- get_button_status(joy, button) 	//Returns 0 or 1 if button is pressed or not.
+-- get_axis_status(joy, axis)		//Returns the axis position value
+
+-- Get methods for virtual devices, applies in the same way as for physical devices.
+-- get_vjoy_button_status(vjoy, button)
+-- get_vjoy_axis_status(vjoy, axis)
+
+-- When axis 1 on device 0 is changed, set the axis 1 on virtual device 0, inverted or not depending on button 1 on device 0.
+function d0_a6_event(value)
+	send_axis_event(0, 0, value)
+end
+function d0_a7_event(value)
+	send_axis_event(0, 1, value)
+end
+-- Send a button 0 event to virtual device 0 when button 0 on physical device 0 is pressed and released.
+function d0_b1_event(value)
+	if value == 1 then
+	   send_keyboard_event(KEY_LEFTALT, 1)
+	else
+	   send_keyboard_event(KEY_LEFTALT, 0)
+	end
+end

--- a/installService.sh
+++ b/installService.sh
@@ -1,0 +1,19 @@
+if [[ $UID != 0 ]]; then
+    echo "Please run this script with sudo:"
+    echo "sudo $0 $*"
+    exit 1
+fi
+if [ "$#" -ne 1 ]
+then
+  echo "Please provide the lua script that will be installed as a service in /etc/wejoy/config.lua"
+  echo "Usage: ./installService.sh CONFIG_SCRIPT.lua"
+  exit 1
+fi
+
+mkdir -p /etc/wejoy
+cp $1 /etc/wejoy/config.lua
+cp wejoy.service /etc/systemd/system/
+systemctl daemon-reload
+systemctl start wejoy
+systemctl enable wejoy
+echo "Wejoy was installed and started. You can test it on your gamepad settings or with evtest"

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,12 @@ If the module uinput is not loaded on your system, you need to manually load it:
 *
 * You can quit 'wejoy' by pressing 'q' end then 'ENTER'.
 
+# Install it as a service ----
+
+If you want to have a permanent config script running, you may also install wejoy as a service by running the `installService.sh` script
+This script will create a systemd service that starts on boot and copy the script config you want to `/etc/wejoy/config.lua`.
+Example: `sudo ./installService.sh il2_missing_axis.lua`
+
 # LUA scripting ----
 * Please read the example.lua and warthog_throttle.lua to learn how to customize your script.
 * Also read the keycodes_ref.txt for keyboard reference. These variables are globally accessable in your LUA script.

--- a/wejoy.service
+++ b/wejoy.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=wejoy
+
+[Service]
+Type=idle
+ExecStart=/usr/bin/wejoy /etc/wejoy/config.lua
+Restart=always
+Environment=PATH=/usr/bin:/usr/local/bin
+WorkingDirectory=/etc/wejoy
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hey there!

I had been looking for a program like wejoy that allowed me to create a virtual joystick in order to bypass a bug on IL2 Battle of Stalingrad which doesn't recognise the slider axis for the Thrustmaster T16000 Throtle (the small wheel on the throtle + the rudder axis on the pedals). I've added a profile (il2_missing_axis.lua) that create a virtual joystick with those 2 axis. It also sets one button to act as an ALT Modifier, as a way to duplicate the available buttons.

I also included a script to install wejoy as a systemd service that starts on boot with our preferred config, thus avoiding the need of running the script everytime we want to use it. Just run `sudo ./installService.sh il2_missing_axis.lua` and it will create the service with the LUA script profile you want to use.

Hope it is useful for someone else! :)